### PR TITLE
Implemented HTML decoding to remove HTML entities

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -4,4 +4,4 @@ MYSQL_USER = root
 MYSQL_PASSWORD = 
 MYSQL_DATABASE = scoreboard
 # Port
-PORT = 3000
+PORT = 3001

--- a/server/api/fetchQuestion.js
+++ b/server/api/fetchQuestion.js
@@ -1,6 +1,7 @@
 // search for 10 random questions
 
 const axios = require("axios");
+const he = require("he");
 
 const fetchQuestion = {
   //imported from postman (node.js axios)
@@ -17,17 +18,20 @@ const fetchQuestion = {
       const results = response.data.results;
       const allQuestions = [];
       for (let i = 0; i < results.length; i++) {
-        const question = results[i].question;
-        const correctAnswer = results[i].correct_answer;
+        const question = he.decode(results[i].question);
+        const correctAnswer = he.decode(results[i].correct_answer);
         const answerOptions = [
           correctAnswer, //using spread method to combine correct answer string and array of incorrect answers
           ...results[i].incorrect_answers,
         ].sort(() => Math.random() - 0.5); //returns a random positive or negative number for each comparison in the array so the sort method randomly sorts the array
+        const answerOptionsDecoded = answerOptions.map((answer) =>
+          he.decode(answer),
+        );
         allQuestions.push({
           //Note: the structure of this object can change if needed in the FE
           id: i + 1,
           question: question,
-          answerOptions: answerOptions,
+          answerOptions: answerOptionsDecoded,
           correctAnswer: correctAnswer,
         });
       }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.3",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "he": "^1.2.0",
         "mysql2": "^3.10.1"
       },
       "devDependencies": {
@@ -1276,6 +1277,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/http-errors": {

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.7.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "he": "^1.2.0",
     "mysql2": "^3.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I've installed a new library 'he' to decode the HTML entities returned from the html requests.
About he library: https://www.npmjs.com/package/he

Please run npm install next time you pull from staging.

In the backend fetchQuestion.js file, the he.decode() function converts html entities into normal string characters. I've run he.decode() on the question and answers so when they're returned to frontend they don't have weird characters anymore.

Additionally changed default port in .env example to 3001 as usually our frontend is running on 3000 so makes it easier. 