### PR TITLE
Fix/g6 105 jacquelyn styling scoreboard

### DIFF
--- a/client/src/components/ScoreList/ScoreList.css
+++ b/client/src/components/ScoreList/ScoreList.css
@@ -18,6 +18,7 @@
 
 .user-name {
   font-weight: 400;
+  width: 10rem;
 }
 
 .user-result {

--- a/client/src/pages/LandingPage/LandingPage.js
+++ b/client/src/pages/LandingPage/LandingPage.js
@@ -79,7 +79,7 @@ function LandingPage() {
       <BrowserTab title="Triviago" />
       <div className="content">
         <MainHeading title="Welcome to" />
-        <MainHeading className="gradient-pink" title="Quiz App" />
+        <MainHeading className="gradient-pink" title="Triviago" />
         {!isSubmitted && (
           <form id="name-form" onSubmit={handleSubmit}>
             <label htmlFor="player-name">


### PR DESCRIPTION
Added a width to the user column so that the percentages are now inline
<img width="942" alt="Screenshot 2024-08-24 at 10 49 20" src="https://github.com/user-attachments/assets/795d8a03-0703-4eda-b315-57fdc5135f78">
